### PR TITLE
.noConflict() support

### DIFF
--- a/lib/jquery.offline.js
+++ b/lib/jquery.offline.js
@@ -41,7 +41,7 @@
 
   // modified getJSON which uses ifModified: true
   function getJSON(url, data, fn) {
-    if (jQuery.isFunction(data)) {
+    if ($.isFunction(data)) {
       fn = data;
       data = null;
     }
@@ -53,7 +53,7 @@
 
     requesting[requestingKey] = true;
 
-    return jQuery.ajax({
+    return $.ajax({
       type: "GET",
       url: url,
       data: data,
@@ -96,7 +96,7 @@
     // If the user goes offline, hide any loading bar
     // the user may have created
     $(window).bind("offline", function() {
-      jQuery.event.trigger("ajaxStop");
+      $.event.trigger("ajaxStop");
     });
 
     $.retrieveJSON = function(url, data, fn) {


### PR DESCRIPTION
There were a few references to jQuery as jQuery, not $, inside the closure.
