### PR TITLE
Queue callbacks while requesting

### DIFF
--- a/lib/jquery.offline.js
+++ b/lib/jquery.offline.js
@@ -48,18 +48,17 @@
 
     var requestingKey = url + "?" + $.param(data || {});
     if (requesting[requestingKey]) {
+      requesting[requestingKey].push(fn);
       return false;
     }
 
-    requesting[requestingKey] = true;
+    requesting[requestingKey] = [fn];
 
     return jQuery.ajax({
       type: "GET",
       url: url,
       data: data,
       success: function(responseData, text) {
-        delete requesting[requestingKey];
-
         // handle lack of response (error callback isn't called in this case)
         if (undefined === responseData) {
           if (!window.navigator.onLine) {
@@ -71,9 +70,11 @@
           return;
         }
 
-        fn(responseData, text);
+        $.each(requesting[requestingKey], function (i, fn) {
+          fn(responseData, text);
+        });
       },
-      error: function() {
+      complete: function() {
         delete requesting[requestingKey];
       },
       dataType: "json",


### PR DESCRIPTION
If a few widgets load the same data, they should all be notified when the data is loaded. Previously only the first widget's callback would be called.
